### PR TITLE
fix the possibility for pthread_detach(0)

### DIFF
--- a/deps/worker.c
+++ b/deps/worker.c
@@ -144,10 +144,10 @@ static void *worker_entry(void *arg) {
         ts.tv_sec += 1;
         pthread_cond_timedwait(&thread->cond, &thread->mu, &ts);
         if (thread->len == 0) {
-            thread->th = 0;
             if (!thread->end) {
                 pthread_detach(thread->th);
             }
+            thread->th = 0;
             thread->end = false;
             break;
         }

--- a/neco.c
+++ b/neco.c
@@ -2739,10 +2739,10 @@ static void *worker_entry(void *arg) {
         ts.tv_sec += 1;
         pthread_cond_timedwait(&thread->cond, &thread->mu, &ts);
         if (thread->len == 0) {
-            thread->th = 0;
             if (!thread->end) {
                 pthread_detach(thread->th);
             }
+            thread->th = 0;
             thread->end = false;
             break;
         }


### PR DESCRIPTION
Please do not open a pull request without first filing an issue and/or discussing the feature directly with me.

### Please ensure you adhere to every item in this list

- [x] This PR was pre-approved by the project maintainer
- [x] I have self-reviewed the code
- [ ] I have added all necessary tests

### Describe your changes

When detaching a thread, there is a certain case where that `pthread_t` variable could be 0. On my system, `pthread_detach(0)` is causing a segfault, crashing the program. On other systems (and according to the man page), it shouldn't segfault but instead gracefully return an error code, however in that case it _is_ still an error, and I believe it should be fixed in this way, in any case.

### Issue number and link

#1 
