### PR TITLE
fixes alignment on opaque types as discueed with @tidwall

### DIFF
--- a/neco.c
+++ b/neco.c
@@ -7063,6 +7063,7 @@ struct neco_mutex {
 
 
 static_assert(sizeof(neco_mutex) >= sizeof(struct neco_mutex), "");
+static_assert(_Alignof(neco_mutex) == _Alignof(struct neco_mutex), "");
 
 static int mutex_init(neco_mutex *mutex) {
     struct neco_mutex *mu = (void*)mutex;
@@ -7319,6 +7320,7 @@ struct neco_waitgroup {
 };
 
 static_assert(sizeof(neco_waitgroup) >= sizeof(struct neco_waitgroup), "");
+static_assert(_Alignof(neco_waitgroup) == _Alignof(struct neco_waitgroup), "");
 
 inline
 static int check_waitgroup(struct neco_waitgroup *wg) {
@@ -7466,6 +7468,7 @@ struct neco_cond {
 };
 
 static_assert(sizeof(neco_cond) >= sizeof(struct neco_cond), "");
+static_assert(_Alignof(neco_cond) == _Alignof(struct neco_cond), "");
 
 static int cond_init0(struct neco_cond *cv) {
     memset(cv, 0, sizeof(struct neco_cond));

--- a/neco.h
+++ b/neco.h
@@ -106,7 +106,7 @@ int neco_gen_close(neco_gen *gen);
 /// to a variable or set of variables and helps to avoid data inconsistencies
 /// due to race conditions.
 /// @{
-typedef struct { char _[48]; } neco_mutex;
+typedef struct { _Alignas(16) char _[48]; } neco_mutex;
 
 #define NECO_MUTEX_INITIALIZER { 0 }
 
@@ -128,7 +128,7 @@ int neco_mutex_tryrdlock(neco_mutex *mutex);
 /// At the same time, neco_waitgroup_wait() can be used to block until all
 /// coroutines are completed.
 /// @{
-typedef struct { char _[48]; } neco_waitgroup;
+typedef struct { _Alignas(16) char _[48]; } neco_waitgroup;
 
 #define NECO_WAITGROUP_INITIALIZER { 0 }
 
@@ -143,7 +143,7 @@ int neco_waitgroup_wait_dl(neco_waitgroup *waitgroup, int64_t deadline);
 /// A condition variable is a synchronization mechanism that allows coroutines
 /// to suspend execution until some condition is true. 
 /// @{
-typedef struct { char _[48]; } neco_cond;
+typedef struct { _Alignas(16) char _[48]; } neco_cond;
 #define NECO_COND_INITIALIZER { 0 }
 
 int neco_cond_init(neco_cond *cond);


### PR DESCRIPTION
Please do not open a pull request without first filing an issue and/or discussing the feature directly with me.

### Please ensure you adhere to every item in this list

- [x] This PR was pre-approved by the project maintainer
- [x] I have self-reviewed the code
- [x] I have added all necessary tests

### Describe your changes

Please provide detailed description of the changes.

When using this library from Zig, the Zig compiler caught some undefined behavior with respect to the opaque types. The fix as discussed with @tidwall was to override the default alignment on the exported opaque types and added the necessary static_assert checks to the internal types such that they match.

https://github.com/tidwall/neco/issues/11